### PR TITLE
fix: update style.css

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -609,6 +609,7 @@ section {
 
 .hero {
   padding: 0;
+  padding-top: 56px;
   background-image: url('../img/pride-flag.webp');
   background-size: cover;
   background-repeat: no-repeat;


### PR DESCRIPTION
Making the nav bar sticky caused an unintended side effect where the hero images were pulled up under it. Have added additional padding to compensate for the height of the nav